### PR TITLE
Additional options

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,15 @@
 var _ = require('lodash');
 
 module.exports = function(parties, options) {
-  options = options || {};
   parties = _.cloneDeep(parties);
+  options = _.defaults(options, {
+      seats: 120,
+      threshold: 0.05
+  });
 
   var allocated = 0,
     party,
-    seats = options.seats || 120,
+    seats = options.seats,
     totalVotes;
 
   totalVotes = _.reduce(_.map(parties, 'votes'), function(total, votes) {
@@ -15,7 +18,7 @@ module.exports = function(parties, options) {
 
   _.each(parties, function(party) {
     party.allocated = 0;
-    if (party.electorates > 0 || (party.votes / totalVotes) > 0.05) {
+    if (party.electorates > 0 || (party.votes / totalVotes) > options.threshold) {
       party.quotient = party.votes;
     }
 

--- a/index.js
+++ b/index.js
@@ -1,41 +1,45 @@
 var _ = require('lodash');
 
-module.exports = function(parties, options) {
+module.exports = function saintLague(parties, options) {
   parties = _.cloneDeep(parties);
   options = _.defaults(options, {
       seats: 120,
-      threshold: 0.05
+      threshold: 0.05,
+      overhang: true
   });
 
   var allocated = 0,
     party,
-    seats = options.seats,
+    quotients = options.quotients || options.seats,
+    seats,
     totalVotes;
 
-  totalVotes = _.reduce(_.map(parties, 'votes'), function(total, votes) {
-    return total + votes;
+  totalVotes = _.reduce(parties, function(total, party) {
+    return total + party.votes;
   }, 0);
 
   _.each(parties, function(party) {
     party.allocated = 0;
-    if (party.electorates > 0 || (party.votes / totalVotes) > options.threshold) {
+    if (party.electorates > 0 || (party.votes / totalVotes) >= options.threshold) {
       party.quotient = party.votes;
     }
 
+    // Allows a party to be excluded without messing up results.
+    // Useful with early results.
     if (party.votes === -1) {
-      seats -= party.electorates;
+      quotients -= party.electorates;
       party.allocated = party.electorates;
     }
   });
 
-  while (allocated < seats) {
+  while (allocated < quotients) {
     party = _.maxBy(parties, 'quotient');
     party.allocated++;
     party.quotient = party.votes / ((2 * party.allocated) + 1);
     allocated++;
   }
 
-  return _.map(parties, function(party) {
+  parties = _.map(parties, function(party) {
     if (party.electorates > party.allocated) {
       party.lists = 0;
     } else {
@@ -50,4 +54,16 @@ module.exports = function(parties, options) {
 
     return _.omit(party, 'quotient');
   });
+
+  seats = _.reduce(parties, function(total, party) {
+    return total + party.allocated;
+  }, 0);
+
+  // If overhang isn't allowed and overhang is detected
+  // recalculate with less quotients.
+  if (!options.overhang && seats > options.seats) {
+    return saintLague(parties, _.assign({ quotients: ((2 * options.seats) - seats)  }, options));
+  }
+
+  return parties;
 };

--- a/index.js
+++ b/index.js
@@ -5,7 +5,9 @@ module.exports = function saintLague(parties, options) {
   options = _.defaults(options, {
       seats: 120,
       threshold: 0.05,
-      overhang: true
+      overhang: true,
+      tagAlong: true,
+      tagAlongSeats: 1
   });
 
   var allocated = 0,
@@ -20,7 +22,7 @@ module.exports = function saintLague(parties, options) {
 
   _.each(parties, function(party) {
     party.allocated = 0;
-    if (party.electorates > 0 || (party.votes / totalVotes) >= options.threshold) {
+    if ((options.tagAlong && party.electorates >= options.tagAlongSeats) || (party.votes / totalVotes) >= options.threshold) {
       party.quotient = party.votes;
     }
 

--- a/test/example.js
+++ b/test/example.js
@@ -1,0 +1,37 @@
+var lague = require('../index');
+
+module.exports['test lague calculations'] = function(test) {
+  var parties,
+    result;
+
+  parties = [
+      { name: 'A', votes: 100, electorates: 1 },
+      { name: 'B', votes: 5, electorates: 10 },
+      { name: 'C', votes: 5, electorates: 0 },
+      { name: 'D', votes: 50, electorates: 1, listSize: 5 },
+      { name: 'E', votes: -1, electorates: 5 }
+    ];
+
+  result = lague(parties, { seats: 120 });
+
+  // doesn't pollute original array
+  test.equals(parties[0].allocated, undefined);
+
+  test.equals(result.length, 5);
+
+  // allocated
+  test.equals(result[0].allocated, 74);
+  test.equals(result[1].allocated, 10);
+  test.equals(result[2].allocated, 0);
+  test.equals(result[3].allocated, 37);
+  test.equals(result[4].allocated, 5);
+
+  // lists
+  test.equals(result[0].lists, 73);
+  test.equals(result[1].lists, 0);
+  test.equals(result[2].lists, 0);
+  test.equals(result[3].lists, 5);
+  test.equals(result[4].lists, 0);
+
+  test.done();
+};

--- a/test/nz-elections.js
+++ b/test/nz-elections.js
@@ -1,41 +1,5 @@
 var lague = require('../index');
 
-module.exports['test lague calculations'] = function(test) {
-  var parties,
-    result;
-
-  parties = [
-      { name: 'A', votes: 100, electorates: 1 },
-      { name: 'B', votes: 5, electorates: 10 },
-      { name: 'C', votes: 5, electorates: 0 },
-      { name: 'D', votes: 50, electorates: 1, listSize: 5 },
-      { name: 'E', votes: -1, electorates: 5 }
-    ];
-
-  result = lague(parties, { seats: 120 });
-
-  // doesn't pollute original array
-  test.equals(parties[0].allocated, undefined);
-
-  test.equals(result.length, 5);
-
-  // allocated
-  test.equals(result[0].allocated, 74);
-  test.equals(result[1].allocated, 10);
-  test.equals(result[2].allocated, 0);
-  test.equals(result[3].allocated, 37);
-  test.equals(result[4].allocated, 5);
-
-  // lists
-  test.equals(result[0].lists, 73);
-  test.equals(result[1].lists, 0);
-  test.equals(result[2].lists, 0);
-  test.equals(result[3].lists, 5);
-  test.equals(result[4].lists, 0);
-
-  test.done();
-};
-
 module.exports['2014 NZ election'] = function(test) {
   var parties,
     result;
@@ -58,7 +22,11 @@ module.exports['2014 NZ election'] = function(test) {
     { votes: 677, electorates: 0 }
   ];
 
-  result = lague(parties, { seats: 120, threshold: 0.05 });
+  result = lague(parties, {
+    seats: 120,
+    threshold: 0.05,
+    overhang: true
+  });
 
   // allocated
   test.equals(result[0].allocated, 61);
@@ -100,7 +68,11 @@ module.exports['2011 NZ election'] = function(test) {
     { votes: 1209, electorates: 0 }
   ];
 
-  result = lague(parties, { seats: 120, threshold: 0.05 });
+  result = lague(parties, {
+    seats: 120,
+    threshold: 0.05,
+    overhang: true
+  });
 
   // allocated
   test.equals(result[0].allocated, 59);
@@ -146,7 +118,11 @@ module.exports['2008 NZ election'] = function(test) {
     { votes: 313, electorates: 0 }
   ];
 
-  result = lague(parties, { seats: 120, threshold: 0.05 });
+  result = lague(parties, {
+    seats: 120,
+    threshold: 0.05,
+    overhang: true
+  });
 
   // allocated
   test.equals(result[0].allocated, 58);
@@ -198,7 +174,11 @@ module.exports['2005 NZ election'] = function(test) {
     { votes: 344, electorates: 0 }
   ];
 
-  result = lague(parties, { seats: 120, threshold: 0.05 });
+  result = lague(parties, {
+    seats: 120,
+    threshold: 0.05,
+    overhang: true
+  });
 
   // allocated
   test.equals(result[0].allocated, 50);
@@ -245,7 +225,11 @@ module.exports['2002 NZ election'] = function(test) {
     { votes: 274, electorates: 0 }
   ];
 
-  result = lague(parties, { seats: 120, threshold: 0.05 });
+  result = lague(parties, {
+    seats: 120,
+    threshold: 0.05,
+    overhang: true
+  });
 
   // allocated
   test.equals(result[0].allocated, 52);
@@ -295,7 +279,11 @@ module.exports['1999 NZ election'] = function(test) {
     { votes: 292, electorates: 0 }
   ];
 
-  result = lague(parties, { seats: 120, threshold: 0.05 });
+  result = lague(parties, {
+    seats: 120,
+    threshold: 0.05,
+    overhang: true
+  });
 
   // allocated
   test.equals(result[0].allocated, 49);
@@ -352,7 +340,11 @@ module.exports['1996 NZ election'] = function(test) {
     { votes: 404, electorates: 0 }
   ];
 
-  result = lague(parties, { seats: 120, threshold: 0.05 });
+  result = lague(parties, {
+    seats: 120,
+    threshold: 0.05,
+    overhang: true
+  });
 
   // allocated
   test.equals(result[0].allocated, 44);

--- a/test/nz-elections.js
+++ b/test/nz-elections.js
@@ -22,11 +22,7 @@ module.exports['2014 NZ election'] = function(test) {
     { votes: 677, electorates: 0 }
   ];
 
-  result = lague(parties, {
-    seats: 120,
-    threshold: 0.05,
-    overhang: true
-  });
+  result = lague(parties, { seats: 120 });
 
   // allocated
   test.equals(result[0].allocated, 61);
@@ -68,11 +64,7 @@ module.exports['2011 NZ election'] = function(test) {
     { votes: 1209, electorates: 0 }
   ];
 
-  result = lague(parties, {
-    seats: 120,
-    threshold: 0.05,
-    overhang: true
-  });
+  result = lague(parties, { seats: 120 });
 
   // allocated
   test.equals(result[0].allocated, 59);
@@ -118,11 +110,7 @@ module.exports['2008 NZ election'] = function(test) {
     { votes: 313, electorates: 0 }
   ];
 
-  result = lague(parties, {
-    seats: 120,
-    threshold: 0.05,
-    overhang: true
-  });
+  result = lague(parties, { seats: 120 });
 
   // allocated
   test.equals(result[0].allocated, 58);
@@ -174,11 +162,7 @@ module.exports['2005 NZ election'] = function(test) {
     { votes: 344, electorates: 0 }
   ];
 
-  result = lague(parties, {
-    seats: 120,
-    threshold: 0.05,
-    overhang: true
-  });
+  result = lague(parties, { seats: 120 });
 
   // allocated
   test.equals(result[0].allocated, 50);
@@ -225,11 +209,7 @@ module.exports['2002 NZ election'] = function(test) {
     { votes: 274, electorates: 0 }
   ];
 
-  result = lague(parties, {
-    seats: 120,
-    threshold: 0.05,
-    overhang: true
-  });
+  result = lague(parties, { seats: 120 });
 
   // allocated
   test.equals(result[0].allocated, 52);
@@ -279,11 +259,7 @@ module.exports['1999 NZ election'] = function(test) {
     { votes: 292, electorates: 0 }
   ];
 
-  result = lague(parties, {
-    seats: 120,
-    threshold: 0.05,
-    overhang: true
-  });
+  result = lague(parties, { seats: 120 });
 
   // allocated
   test.equals(result[0].allocated, 49);
@@ -340,11 +316,7 @@ module.exports['1996 NZ election'] = function(test) {
     { votes: 404, electorates: 0 }
   ];
 
-  result = lague(parties, {
-    seats: 120,
-    threshold: 0.05,
-    overhang: true
-  });
+  result = lague(parties, { seats: 120 });
 
   // allocated
   test.equals(result[0].allocated, 44);

--- a/test/nz-overhang.js
+++ b/test/nz-overhang.js
@@ -1,0 +1,810 @@
+var _ = require('lodash');
+var lague = require('../index');
+
+// All figures are as provided by the 2012 MMP Review Report
+// http://www.elections.org.nz/sites/default/files/bulk-upload/documents/Final_Report_2012_Review_of_MMP.pdf
+
+// 1.61 - Table 4 (Page 21)
+
+module.exports['2011 NZ election - 5% threshold, with overhangs'] = function(test) {
+  var parties,
+    result,
+    total;
+
+  parties = [
+    { votes: 1058636, electorates: 42 },
+    { votes: 614937, electorates: 22 },
+    { votes: 247372, electorates: 0 },
+    { votes: 147544, electorates: 0 },
+    { votes: 59237, electorates: 0 },
+    { votes: 31982, electorates: 3 },
+    { votes: 24168, electorates: 1 },
+    { votes: 23889, electorates: 1 },
+    { votes: 13443, electorates: 1 },
+    { votes: 11738, electorates: 0 },
+    { votes: 1714, electorates: 0 },
+    { votes: 1595, electorates: 0 },
+    { votes: 1209, electorates: 0 }
+  ];
+
+  result = lague(parties, {
+    seats: 120,
+    threshold: 0.05,
+    overhang: true,
+    tagAlong: true
+  });
+
+  total = _.reduce(result, function(total, party) {
+      return total + party.allocated;
+  }, 0);
+
+  // allocated
+  test.equals(result[7].allocated, 1);
+  test.equals(result[2].allocated, 14);
+  test.equals(result[1].allocated, 34);
+  test.equals(result[6].allocated, 1);
+  test.equals(result[5].allocated, 3);
+  test.equals(result[0].allocated, 59);
+  test.equals(result[3].allocated, 8);
+  test.equals(result[8].allocated, 1);
+
+  test.equals(total, 121);
+
+  test.done();
+};
+
+module.exports['2011 NZ election - 4% threshold, without overhangs'] = function(test) {
+  var parties,
+    result,
+    total;
+
+  parties = [
+    { votes: 1058636, electorates: 42 },
+    { votes: 614937, electorates: 22 },
+    { votes: 247372, electorates: 0 },
+    { votes: 147544, electorates: 0 },
+    { votes: 59237, electorates: 0 },
+    { votes: 31982, electorates: 3 },
+    { votes: 24168, electorates: 1 },
+    { votes: 23889, electorates: 1 },
+    { votes: 13443, electorates: 1 },
+    { votes: 11738, electorates: 0 },
+    { votes: 1714, electorates: 0 },
+    { votes: 1595, electorates: 0 },
+    { votes: 1209, electorates: 0 }
+  ];
+
+  result = lague(parties, {
+    seats: 120,
+    threshold: 0.04,
+    overhang: false,
+    tagAlong: false
+  });
+
+  total = _.reduce(result, function(total, party) {
+      return total + party.allocated;
+  }, 0);
+
+  // allocated
+  test.equals(result[7].allocated, 1);
+  test.equals(result[2].allocated, 14);
+  test.equals(result[1].allocated, 34);
+  test.equals(result[6].allocated, 1);
+  test.equals(result[5].allocated, 3);
+  test.equals(result[0].allocated, 58);
+  test.equals(result[3].allocated, 8);
+  test.equals(result[8].allocated, 1);
+
+  test.equals(total, 120);
+
+  test.done();
+};
+
+module.exports['2011 NZ election - 4% threshold, with overhangs'] = function(test) {
+  var parties,
+    result,
+    total;
+
+  parties = [
+    { votes: 1058636, electorates: 42 },
+    { votes: 614937, electorates: 22 },
+    { votes: 247372, electorates: 0 },
+    { votes: 147544, electorates: 0 },
+    { votes: 59237, electorates: 0 },
+    { votes: 31982, electorates: 3 },
+    { votes: 24168, electorates: 1 },
+    { votes: 23889, electorates: 1 },
+    { votes: 13443, electorates: 1 },
+    { votes: 11738, electorates: 0 },
+    { votes: 1714, electorates: 0 },
+    { votes: 1595, electorates: 0 },
+    { votes: 1209, electorates: 0 }
+  ];
+
+  result = lague(parties, {
+    seats: 120,
+    threshold: 0.04,
+    overhang: true,
+    tagAlong: false
+  });
+
+  total = _.reduce(result, function(total, party) {
+      return total + party.allocated;
+  }, 0);
+
+  // allocated
+  test.equals(result[7].allocated, 1);
+  test.equals(result[2].allocated, 14);
+  test.equals(result[1].allocated, 36);
+  test.equals(result[6].allocated, 1);
+  test.equals(result[5].allocated, 3);
+  test.equals(result[0].allocated, 61);
+  test.equals(result[3].allocated, 9);
+  test.equals(result[8].allocated, 1);
+
+  test.equals(total, 126);
+
+  test.done();
+};
+
+// 1.69 - Table 6 (Page 23)
+
+module.exports['2008 NZ election - 5% threshold, with overhangs'] = function(test) {
+  var parties,
+    result,
+    total;
+
+  parties = [
+    { votes: 1053398, electorates: 41 },
+    { votes: 796880, electorates: 21 },
+    { votes: 157613, electorates: 0 },
+    { votes: 95356, electorates: 0 },
+    { votes: 85496, electorates: 1 },
+    { votes: 55980, electorates: 5 },
+    { votes: 21241, electorates: 1 },
+    { votes: 20497, electorates: 1 },
+    { votes: 13016, electorates: 0 },
+    { votes: 12755, electorates: 0 },
+    { votes: 9515, electorates: 0 },
+    { votes: 9640, electorates: 0 },
+    { votes: 8176, electorates: 0 },
+    { votes: 1909, electorates: 0 },
+    { votes: 1208, electorates: 0 },
+    { votes: 1176, electorates: 0 },
+    { votes: 932, electorates: 0 },
+    { votes: 465, electorates: 0 },
+    { votes: 313, electorates: 0 }
+  ];
+
+  result = lague(parties, {
+    seats: 120,
+    threshold: 0.05,
+    overhang: true,
+    tagAlong: true
+  });
+
+  total = _.reduce(result, function(total, party) {
+      return total + party.allocated;
+  }, 0);
+
+  test.equals(result[0].allocated + result[4].allocated + result[5].allocated + result[7].allocated, 69);
+  test.equals(total, 122);
+
+  test.done();
+};
+
+module.exports['2008 NZ election - 4% threshold, without overhangs'] = function(test) {
+  var parties,
+    result,
+    total;
+
+  parties = [
+    { votes: 1053398, electorates: 41 },
+    { votes: 796880, electorates: 21 },
+    { votes: 157613, electorates: 0 },
+    { votes: 95356, electorates: 0 },
+    { votes: 85496, electorates: 1 },
+    { votes: 55980, electorates: 5 },
+    { votes: 21241, electorates: 1 },
+    { votes: 20497, electorates: 1 },
+    { votes: 13016, electorates: 0 },
+    { votes: 12755, electorates: 0 },
+    { votes: 9515, electorates: 0 },
+    { votes: 9640, electorates: 0 },
+    { votes: 8176, electorates: 0 },
+    { votes: 1909, electorates: 0 },
+    { votes: 1208, electorates: 0 },
+    { votes: 1176, electorates: 0 },
+    { votes: 932, electorates: 0 },
+    { votes: 465, electorates: 0 },
+    { votes: 313, electorates: 0 }
+  ];
+
+  result = lague(parties, {
+    seats: 120,
+    threshold: 0.04,
+    overhang: false,
+    tagAlong: false
+  });
+
+  total = _.reduce(result, function(total, party) {
+      return total + party.allocated;
+  }, 0);
+
+  test.equals(result[0].allocated + result[4].allocated + result[5].allocated + result[7].allocated, 63);
+  test.equals(total, 120);
+
+  test.done();
+};
+
+module.exports['2008 NZ election - 4% threshold, with overhangs'] = function(test) {
+  var parties,
+    result,
+    total;
+
+  parties = [
+    { votes: 1053398, electorates: 41 },
+    { votes: 796880, electorates: 21 },
+    { votes: 157613, electorates: 0 },
+    { votes: 95356, electorates: 0 },
+    { votes: 85496, electorates: 1 },
+    { votes: 55980, electorates: 5 },
+    { votes: 21241, electorates: 1 },
+    { votes: 20497, electorates: 1 },
+    { votes: 13016, electorates: 0 },
+    { votes: 12755, electorates: 0 },
+    { votes: 9515, electorates: 0 },
+    { votes: 9640, electorates: 0 },
+    { votes: 8176, electorates: 0 },
+    { votes: 1909, electorates: 0 },
+    { votes: 1208, electorates: 0 },
+    { votes: 1176, electorates: 0 },
+    { votes: 932, electorates: 0 },
+    { votes: 465, electorates: 0 },
+    { votes: 313, electorates: 0 }
+  ];
+
+  result = lague(parties, {
+    seats: 120,
+    threshold: 0.04,
+    overhang: true,
+    tagAlong: false
+  });
+
+  total = _.reduce(result, function(total, party) {
+      return total + party.allocated;
+  }, 0);
+
+  test.equals(result[0].allocated + result[4].allocated + result[5].allocated + result[7].allocated, 67);
+  test.equals(total, 128);
+
+  test.done();
+};
+
+module.exports['2005 NZ election - 5% threshold, with overhangs'] = function(test) {
+  var parties,
+    result,
+    total;
+
+  parties = [
+    { votes: 935319, electorates: 31 },
+    { votes: 889813, electorates: 31 },
+    { votes: 130115, electorates: 0 },
+    { votes: 120521, electorates: 0 },
+    { votes: 48263, electorates: 4 },
+    { votes: 60860, electorates: 1 },
+    { votes: 34469, electorates: 1 },
+    { votes: 26441, electorates: 1 },
+    { votes: 14210, electorates: 0 },
+    { votes: 5748, electorates: 0 },
+    { votes: 2821, electorates: 0 },
+    { votes: 1641, electorates: 0 },
+    { votes: 1178, electorates: 0 },
+    { votes: 1079, electorates: 0 },
+    { votes: 946, electorates: 0 },
+    { votes: 782, electorates: 0 },
+    { votes: 601, electorates: 0 },
+    { votes: 478, electorates: 0 },
+    { votes: 344, electorates: 0 }
+  ];
+
+  result = lague(parties, {
+    seats: 120,
+    threshold: 0.05,
+    overhang: true,
+    tagAlong: true
+  });
+
+  total = _.reduce(result, function(total, party) {
+      return total + party.allocated;
+  }, 0);
+
+  test.equals(result[0].allocated + result[7].allocated + result[2].allocated + result[5].allocated, 61);
+  test.equals(total, 121);
+
+  test.done();
+};
+
+module.exports['2005 NZ election - 4% threshold, without overhangs'] = function(test) {
+  var parties,
+    result,
+    total;
+
+  parties = [
+    { votes: 935319, electorates: 31 },
+    { votes: 889813, electorates: 31 },
+    { votes: 130115, electorates: 0 },
+    { votes: 120521, electorates: 0 },
+    { votes: 48263, electorates: 4 },
+    { votes: 60860, electorates: 1 },
+    { votes: 34469, electorates: 1 },
+    { votes: 26441, electorates: 1 },
+    { votes: 14210, electorates: 0 },
+    { votes: 5748, electorates: 0 },
+    { votes: 2821, electorates: 0 },
+    { votes: 1641, electorates: 0 },
+    { votes: 1178, electorates: 0 },
+    { votes: 1079, electorates: 0 },
+    { votes: 946, electorates: 0 },
+    { votes: 782, electorates: 0 },
+    { votes: 601, electorates: 0 },
+    { votes: 478, electorates: 0 },
+    { votes: 344, electorates: 0 }
+  ];
+
+  result = lague(parties, {
+    seats: 120,
+    threshold: 0.04,
+    overhang: false,
+    tagAlong: false
+  });
+
+  total = _.reduce(result, function(total, party) {
+      return total + party.allocated;
+  }, 0);
+
+  test.equals(result[0].allocated + result[7].allocated + result[2].allocated + result[5].allocated, 60);
+  test.equals(total, 120);
+
+  test.done();
+};
+
+module.exports['2005 NZ election - 4% threshold, with overhangs'] = function(test) {
+  var parties,
+    result,
+    total;
+
+  parties = [
+    { votes: 935319, electorates: 31 },
+    { votes: 889813, electorates: 31 },
+    { votes: 130115, electorates: 0 },
+    { votes: 120521, electorates: 0 },
+    { votes: 48263, electorates: 4 },
+    { votes: 60860, electorates: 1 },
+    { votes: 34469, electorates: 1 },
+    { votes: 26441, electorates: 1 },
+    { votes: 14210, electorates: 0 },
+    { votes: 5748, electorates: 0 },
+    { votes: 2821, electorates: 0 },
+    { votes: 1641, electorates: 0 },
+    { votes: 1178, electorates: 0 },
+    { votes: 1079, electorates: 0 },
+    { votes: 946, electorates: 0 },
+    { votes: 782, electorates: 0 },
+    { votes: 601, electorates: 0 },
+    { votes: 478, electorates: 0 },
+    { votes: 344, electorates: 0 }
+  ];
+
+  result = lague(parties, {
+    seats: 120,
+    threshold: 0.04,
+    overhang: true,
+    tagAlong: false
+  });
+
+  total = _.reduce(result, function(total, party) {
+      return total + party.allocated;
+  }, 0);
+
+  test.equals(result[0].allocated + result[7].allocated + result[2].allocated + result[5].allocated, 64);
+  test.equals(total, 127);
+
+  test.done();
+};
+
+module.exports['2002 NZ election - 5% threshold, with overhangs'] = function(test) {
+  var parties,
+    result,
+    total;
+
+  parties = [
+    { votes: 838219, electorates: 45 },
+    { votes: 425310, electorates: 21 },
+    { votes: 210912, electorates: 1 },
+    { votes: 145078, electorates: 0 },
+    { votes: 142250, electorates: 0 },
+    { votes: 135918, electorates: 1 },
+    { votes: 34542, electorates: 1 },
+    { votes: 27492, electorates: 0 },
+    { votes: 25985, electorates: 0 },
+    { votes: 25888, electorates: 0 },
+    { votes: 12987, electorates: 0 },
+    { votes: 4980, electorates: 0 },
+    { votes: 1782, electorates: 0 },
+    { votes: 274, electorates: 0 }
+  ];
+
+  result = lague(parties, {
+    seats: 120,
+    threshold: 0.05,
+    overhang: true,
+    tagAlong: true
+  });
+
+  total = _.reduce(result, function(total, party) {
+      return total + party.allocated;
+  }, 0);
+
+  test.equals(result[0].allocated + result[6].allocated + result[5].allocated, 62);
+  test.equals(total, 120);
+
+  test.done();
+};
+
+module.exports['2002 NZ election - 4% threshold, without overhangs'] = function(test) {
+  var parties,
+    result,
+    total;
+
+  parties = [
+    { votes: 838219, electorates: 45 },
+    { votes: 425310, electorates: 21 },
+    { votes: 210912, electorates: 1 },
+    { votes: 145078, electorates: 0 },
+    { votes: 142250, electorates: 0 },
+    { votes: 135918, electorates: 1 },
+    { votes: 34542, electorates: 1 },
+    { votes: 27492, electorates: 0 },
+    { votes: 25985, electorates: 0 },
+    { votes: 25888, electorates: 0 },
+    { votes: 12987, electorates: 0 },
+    { votes: 4980, electorates: 0 },
+    { votes: 1782, electorates: 0 },
+    { votes: 274, electorates: 0 }
+  ];
+
+  result = lague(parties, {
+    seats: 120,
+    threshold: 0.04,
+    overhang: false,
+    tagAlong: false
+  });
+
+  total = _.reduce(result, function(total, party) {
+      return total + party.allocated;
+  }, 0);
+
+  test.equals(result[0].allocated + result[6].allocated + result[5].allocated, 62);
+  test.equals(total, 120);
+
+  test.done();
+};
+
+module.exports['2002 NZ election - 4% threshold, with overhangs'] = function(test) {
+  var parties,
+    result,
+    total;
+
+  parties = [
+    { votes: 838219, electorates: 45 },
+    { votes: 425310, electorates: 21 },
+    { votes: 210912, electorates: 1 },
+    { votes: 145078, electorates: 0 },
+    { votes: 142250, electorates: 0 },
+    { votes: 135918, electorates: 1 },
+    { votes: 34542, electorates: 1 },
+    { votes: 27492, electorates: 0 },
+    { votes: 25985, electorates: 0 },
+    { votes: 25888, electorates: 0 },
+    { votes: 12987, electorates: 0 },
+    { votes: 4980, electorates: 0 },
+    { votes: 1782, electorates: 0 },
+    { votes: 274, electorates: 0 }
+  ];
+
+  result = lague(parties, {
+    seats: 120,
+    threshold: 0.04,
+    overhang: true,
+    tagAlong: false
+  });
+
+  total = _.reduce(result, function(total, party) {
+      return total + party.allocated;
+  }, 0);
+
+  test.equals(result[0].allocated + result[6].allocated + result[5].allocated, 63);
+  test.equals(total, 121);
+
+  test.done();
+};
+
+module.exports['1999 NZ election - 5% threshold, with overhangs'] = function(test) {
+  var parties,
+    result,
+    total;
+
+  parties = [
+    { votes: 800199, electorates: 41 },
+    { votes: 629932, electorates: 22 },
+    { votes: 159859, electorates: 1 },
+    { votes: 145493, electorates: 0 },
+    { votes: 106560, electorates: 1 },
+    { votes: 87926, electorates: 1 },
+    { votes: 49154, electorates: 0 },
+    { votes: 23033, electorates: 0 },
+    { votes: 22687, electorates: 0 },
+    { votes: 11065, electorates: 1 },
+    { votes: 5949, electorates: 0 },
+    { votes: 5190, electorates: 0 },
+    { votes: 4008, electorates: 0 },
+    { votes: 3244, electorates: 0 },
+    { votes: 3191, electorates: 0 },
+    { votes: 2912, electorates: 0 },
+    { votes: 1712, electorates: 0 },
+    { votes: 1311, electorates: 0 },
+    { votes: 936, electorates: 0 },
+    { votes: 454, electorates: 0 },
+    { votes: 387, electorates: 0 },
+    { votes: 292, electorates: 0 }
+  ];
+
+  result = lague(parties, {
+    seats: 120,
+    threshold: 0.05,
+    overhang: true,
+    tagAlong: true
+  });
+
+  total = _.reduce(result, function(total, party) {
+      return total + party.allocated;
+  }, 0);
+
+  test.equals(result[0].allocated + result[2].allocated, 59);
+  test.equals(total, 120);
+
+  test.done();
+};
+
+module.exports['1999 NZ election - 4% threshold, without overhangs'] = function(test) {
+  var parties,
+    result,
+    total;
+
+  parties = [
+    { votes: 800199, electorates: 41 },
+    { votes: 629932, electorates: 22 },
+    { votes: 159859, electorates: 1 },
+    { votes: 145493, electorates: 0 },
+    { votes: 106560, electorates: 1 },
+    { votes: 87926, electorates: 1 },
+    { votes: 49154, electorates: 0 },
+    { votes: 23033, electorates: 0 },
+    { votes: 22687, electorates: 0 },
+    { votes: 11065, electorates: 1 },
+    { votes: 5949, electorates: 0 },
+    { votes: 5190, electorates: 0 },
+    { votes: 4008, electorates: 0 },
+    { votes: 3244, electorates: 0 },
+    { votes: 3191, electorates: 0 },
+    { votes: 2912, electorates: 0 },
+    { votes: 1712, electorates: 0 },
+    { votes: 1311, electorates: 0 },
+    { votes: 936, electorates: 0 },
+    { votes: 454, electorates: 0 },
+    { votes: 387, electorates: 0 },
+    { votes: 292, electorates: 0 }
+  ];
+
+  result = lague(parties, {
+    seats: 120,
+    threshold: 0.04,
+    overhang: false,
+    tagAlong: false
+  });
+
+  total = _.reduce(result, function(total, party) {
+      return total + party.allocated;
+  }, 0);
+
+  test.equals(result[0].allocated + result[2].allocated, 59);
+  test.equals(total, 120);
+
+  test.done();
+};
+
+module.exports['1999 NZ election - 4% threshold, with overhangs'] = function(test) {
+  var parties,
+    result,
+    total;
+
+  parties = [
+    { votes: 800199, electorates: 41 },
+    { votes: 629932, electorates: 22 },
+    { votes: 159859, electorates: 1 },
+    { votes: 145493, electorates: 0 },
+    { votes: 106560, electorates: 1 },
+    { votes: 87926, electorates: 1 },
+    { votes: 49154, electorates: 0 },
+    { votes: 23033, electorates: 0 },
+    { votes: 22687, electorates: 0 },
+    { votes: 11065, electorates: 1 },
+    { votes: 5949, electorates: 0 },
+    { votes: 5190, electorates: 0 },
+    { votes: 4008, electorates: 0 },
+    { votes: 3244, electorates: 0 },
+    { votes: 3191, electorates: 0 },
+    { votes: 2912, electorates: 0 },
+    { votes: 1712, electorates: 0 },
+    { votes: 1311, electorates: 0 },
+    { votes: 936, electorates: 0 },
+    { votes: 454, electorates: 0 },
+    { votes: 387, electorates: 0 },
+    { votes: 292, electorates: 0 }
+  ];
+
+  result = lague(parties, {
+    seats: 120,
+    threshold: 0.04,
+    overhang: true,
+    tagAlong: false
+  });
+
+  total = _.reduce(result, function(total, party) {
+      return total + party.allocated;
+  }, 0);
+
+  test.equals(result[0].allocated + result[2].allocated, 60);
+  test.equals(total, 121);
+
+  test.done();
+};
+
+module.exports['1996 NZ election - 5% threshold, with overhangs'] = function(test) {
+  var parties,
+    result,
+    total;
+
+  parties = [
+    { votes: 701315, electorates: 30 },
+    { votes: 584159, electorates: 26 },
+    { votes: 276603, electorates: 6 },
+    { votes: 209347, electorates: 1 },
+    { votes: 126442, electorates: 1 },
+    { votes: 89716, electorates: 0 },
+    { votes: 34398, electorates: 0 },
+    { votes: 18245, electorates: 1 },
+    { votes: 5990, electorates: 0 },
+    { votes: 5288, electorates: 0 },
+    { votes: 4070, electorates: 0 },
+    { votes: 3543, electorates: 0 },
+    { votes: 3189, electorates: 0 },
+    { votes: 2514, electorates: 0 },
+    { votes: 2363, electorates: 0 },
+    { votes: 1431, electorates: 0 },
+    { votes: 1244, electorates: 0 },
+    { votes: 949, electorates: 0 },
+    { votes: 671, electorates: 0 },
+    { votes: 478, electorates: 0 },
+    { votes: 404, electorates: 0 }
+  ];
+
+  result = lague(parties, {
+    seats: 120,
+    threshold: 0.05,
+    overhang: true,
+    tagAlong: true
+  });
+
+  total = _.reduce(result, function(total, party) {
+      return total + party.allocated;
+  }, 0);
+
+  test.equals(result[0].allocated + result[2].allocated, 61);
+  test.equals(total, 120);
+
+  test.done();
+};
+
+module.exports['1996 NZ election - 4% threshold, without overhangs'] = function(test) {
+  var parties,
+    result,
+    total;
+
+  parties = [
+    { votes: 701315, electorates: 30 },
+    { votes: 584159, electorates: 26 },
+    { votes: 276603, electorates: 6 },
+    { votes: 209347, electorates: 1 },
+    { votes: 126442, electorates: 1 },
+    { votes: 89716, electorates: 0 },
+    { votes: 34398, electorates: 0 },
+    { votes: 18245, electorates: 1 },
+    { votes: 5990, electorates: 0 },
+    { votes: 5288, electorates: 0 },
+    { votes: 4070, electorates: 0 },
+    { votes: 3543, electorates: 0 },
+    { votes: 3189, electorates: 0 },
+    { votes: 2514, electorates: 0 },
+    { votes: 2363, electorates: 0 },
+    { votes: 1431, electorates: 0 },
+    { votes: 1244, electorates: 0 },
+    { votes: 949, electorates: 0 },
+    { votes: 671, electorates: 0 },
+    { votes: 478, electorates: 0 },
+    { votes: 404, electorates: 0 }
+  ];
+
+  result = lague(parties, {
+    seats: 120,
+    threshold: 0.04,
+    overhang: false,
+    tagAlong: false
+  });
+
+  total = _.reduce(result, function(total, party) {
+      return total + party.allocated;
+  }, 0);
+
+  test.equals(result[0].allocated + result[2].allocated, 59);
+  test.equals(total, 120);
+
+  test.done();
+};
+
+module.exports['1996 NZ election - 4% threshold, with overhangs'] = function(test) {
+  var parties,
+    result,
+    total;
+
+  parties = [
+    { votes: 701315, electorates: 30 },
+    { votes: 584159, electorates: 26 },
+    { votes: 276603, electorates: 6 },
+    { votes: 209347, electorates: 1 },
+    { votes: 126442, electorates: 1 },
+    { votes: 89716, electorates: 0 },
+    { votes: 34398, electorates: 0 },
+    { votes: 18245, electorates: 1 },
+    { votes: 5990, electorates: 0 },
+    { votes: 5288, electorates: 0 },
+    { votes: 4070, electorates: 0 },
+    { votes: 3543, electorates: 0 },
+    { votes: 3189, electorates: 0 },
+    { votes: 2514, electorates: 0 },
+    { votes: 2363, electorates: 0 },
+    { votes: 1431, electorates: 0 },
+    { votes: 1244, electorates: 0 },
+    { votes: 949, electorates: 0 },
+    { votes: 671, electorates: 0 },
+    { votes: 478, electorates: 0 },
+    { votes: 404, electorates: 0 }
+  ];
+
+  result = lague(parties, {
+    seats: 120,
+    threshold: 0.04,
+    overhang: true,
+    tagAlong: false
+  });
+
+  total = _.reduce(result, function(total, party) {
+      return total + party.allocated;
+  }, 0);
+
+  test.equals(result[0].allocated + result[2].allocated, 59);
+  test.equals(total, 121);
+
+  test.done();
+};

--- a/test/test.js
+++ b/test/test.js
@@ -36,34 +36,346 @@ module.exports['test lague calculations'] = function(test) {
   test.done();
 };
 
+module.exports['2014 NZ election'] = function(test) {
+  var parties,
+    result;
+
+  parties = [
+    { votes: 1010464, electorates: 41 },
+    { votes: 519146, electorates: 27 },
+    { votes: 210764, electorates: 0 },
+    { votes: 186031, electorates: 0 },
+    { votes: 86616, electorates: 0 },
+    { votes: 27074, electorates: 1 },
+    { votes: 26539, electorates: 0 },
+    { votes: 14510, electorates: 1 },
+    { votes: 8539, electorates: 0 },
+    { votes: 4533, electorates: 1 },
+    { votes: 4368, electorates: 0 },
+    { votes: 1609, electorates: 0 },
+    { votes: 906, electorates: 0 },
+    { votes: 895, electorates: 0 },
+    { votes: 677, electorates: 0 }
+  ];
+
+  result = lague(parties, { seats: 120, threshold: 0.05 });
+
+  // allocated
+  test.equals(result[0].allocated, 61);
+  test.equals(result[1].allocated, 32);
+  test.equals(result[2].allocated, 13);
+  test.equals(result[3].allocated, 11);
+  test.equals(result[4].allocated, 0);
+  test.equals(result[5].allocated, 2);
+  test.equals(result[6].allocated, 0);
+  test.equals(result[7].allocated, 1);
+  test.equals(result[8].allocated, 0);
+  test.equals(result[9].allocated, 1);
+  test.equals(result[10].allocated, 0);
+  test.equals(result[11].allocated, 0);
+  test.equals(result[12].allocated, 0);
+  test.equals(result[13].allocated, 0);
+  test.equals(result[14].allocated, 0);
+
+  test.done();
+};
+
+module.exports['2011 NZ election'] = function(test) {
+  var parties,
+    result;
+
+  parties = [
+    { votes: 1058636, electorates: 42 },
+    { votes: 614937, electorates: 22 },
+    { votes: 247372, electorates: 0 },
+    { votes: 147544, electorates: 0 },
+    { votes: 59237, electorates: 0 },
+    { votes: 31982, electorates: 3 },
+    { votes: 24168, electorates: 1 },
+    { votes: 23889, electorates: 1 },
+    { votes: 13443, electorates: 1 },
+    { votes: 11738, electorates: 0 },
+    { votes: 1714, electorates: 0 },
+    { votes: 1595, electorates: 0 },
+    { votes: 1209, electorates: 0 }
+  ];
+
+  result = lague(parties, { seats: 120, threshold: 0.05 });
+
+  // allocated
+  test.equals(result[0].allocated, 59);
+  test.equals(result[1].allocated, 34);
+  test.equals(result[2].allocated, 14);
+  test.equals(result[3].allocated, 8);
+  test.equals(result[4].allocated, 0);
+  test.equals(result[5].allocated, 3);
+  test.equals(result[6].allocated, 1);
+  test.equals(result[7].allocated, 1);
+  test.equals(result[8].allocated, 1);
+  test.equals(result[9].allocated, 0);
+  test.equals(result[10].allocated, 0);
+  test.equals(result[11].allocated, 0);
+  test.equals(result[12].allocated, 0);
+
+  test.done();
+};
+
+module.exports['2008 NZ election'] = function(test) {
+  var parties,
+    result;
+
+  parties = [
+    { votes: 1053398, electorates: 41 },
+    { votes: 796880, electorates: 21 },
+    { votes: 157613, electorates: 0 },
+    { votes: 95356, electorates: 0 },
+    { votes: 85496, electorates: 1 },
+    { votes: 55980, electorates: 5 },
+    { votes: 21241, electorates: 1 },
+    { votes: 20497, electorates: 1 },
+    { votes: 13016, electorates: 0 },
+    { votes: 12755, electorates: 0 },
+    { votes: 9515, electorates: 0 },
+    { votes: 9640, electorates: 0 },
+    { votes: 8176, electorates: 0 },
+    { votes: 1909, electorates: 0 },
+    { votes: 1208, electorates: 0 },
+    { votes: 1176, electorates: 0 },
+    { votes: 932, electorates: 0 },
+    { votes: 465, electorates: 0 },
+    { votes: 313, electorates: 0 }
+  ];
+
+  result = lague(parties, { seats: 120, threshold: 0.05 });
+
+  // allocated
+  test.equals(result[0].allocated, 58);
+  test.equals(result[1].allocated, 43);
+  test.equals(result[2].allocated, 9);
+  test.equals(result[3].allocated, 0);
+  test.equals(result[4].allocated, 5);
+  test.equals(result[5].allocated, 5);
+  test.equals(result[6].allocated, 1);
+  test.equals(result[7].allocated, 1);
+  test.equals(result[8].allocated, 0);
+  test.equals(result[9].allocated, 0);
+  test.equals(result[10].allocated, 0);
+  test.equals(result[11].allocated, 0);
+  test.equals(result[12].allocated, 0);
+  test.equals(result[13].allocated, 0);
+  test.equals(result[14].allocated, 0);
+  test.equals(result[15].allocated, 0);
+  test.equals(result[16].allocated, 0);
+  test.equals(result[17].allocated, 0);
+  test.equals(result[18].allocated, 0);
+
+  test.done();
+};
+
 module.exports['2005 NZ election'] = function(test) {
   var parties,
     result;
 
   parties = [
-    { name: 'Labour', votes: 935319, electorates: 31 },
-    { name: 'National', votes: 889813, electorates: 31 },
-    { name: 'NZ First', votes: 130115, electorates: 0 },
-    { name: 'ACT', votes: 34469, electorates: 1 },
-    { name: 'Green', votes: 120521, electorates: 0 },
-    { name: 'UF', votes: 60860, electorates: 1 },
-    { name: 'Progressives', votes: 26441, electorates: 1 },
-    { name: 'Maori Party', votes: 48263, electorates: 4 },
-    { name: 'Other', votes: 29828, electorates: 0 }
+    { votes: 935319, electorates: 31 },
+    { votes: 889813, electorates: 31 },
+    { votes: 130115, electorates: 0 },
+    { votes: 120521, electorates: 0 },
+    { votes: 48263, electorates: 4 },
+    { votes: 60860, electorates: 1 },
+    { votes: 34469, electorates: 1 },
+    { votes: 26441, electorates: 1 },
+    { votes: 14210, electorates: 0 },
+    { votes: 5748, electorates: 0 },
+    { votes: 2821, electorates: 0 },
+    { votes: 1641, electorates: 0 },
+    { votes: 1178, electorates: 0 },
+    { votes: 1079, electorates: 0 },
+    { votes: 946, electorates: 0 },
+    { votes: 782, electorates: 0 },
+    { votes: 601, electorates: 0 },
+    { votes: 478, electorates: 0 },
+    { votes: 344, electorates: 0 }
   ];
 
-  result = lague(parties, { seats: 120 });
+  result = lague(parties, { seats: 120, threshold: 0.05 });
 
   // allocated
   test.equals(result[0].allocated, 50);
   test.equals(result[1].allocated, 48);
   test.equals(result[2].allocated, 7);
-  test.equals(result[3].allocated, 2);
-  test.equals(result[4].allocated, 6);
+  test.equals(result[3].allocated, 6);
+  test.equals(result[4].allocated, 4);
   test.equals(result[5].allocated, 3);
-  test.equals(result[6].allocated, 1);
-  test.equals(result[7].allocated, 4);
+  test.equals(result[6].allocated, 2);
+  test.equals(result[7].allocated, 1);
   test.equals(result[8].allocated, 0);
+  test.equals(result[9].allocated, 0);
+  test.equals(result[10].allocated, 0);
+  test.equals(result[11].allocated, 0);
+  test.equals(result[12].allocated, 0);
+  test.equals(result[13].allocated, 0);
+  test.equals(result[14].allocated, 0);
+  test.equals(result[15].allocated, 0);
+  test.equals(result[16].allocated, 0);
+  test.equals(result[17].allocated, 0);
+  test.equals(result[18].allocated, 0);
+
+  test.done();
+};
+
+module.exports['2002 NZ election'] = function(test) {
+  var parties,
+    result;
+
+  parties = [
+    { votes: 838219, electorates: 45 },
+    { votes: 425310, electorates: 21 },
+    { votes: 210912, electorates: 1 },
+    { votes: 145078, electorates: 0 },
+    { votes: 142250, electorates: 0 },
+    { votes: 135918, electorates: 1 },
+    { votes: 34542, electorates: 1 },
+    { votes: 27492, electorates: 0 },
+    { votes: 25985, electorates: 0 },
+    { votes: 25888, electorates: 0 },
+    { votes: 12987, electorates: 0 },
+    { votes: 4980, electorates: 0 },
+    { votes: 1782, electorates: 0 },
+    { votes: 274, electorates: 0 }
+  ];
+
+  result = lague(parties, { seats: 120, threshold: 0.05 });
+
+  // allocated
+  test.equals(result[0].allocated, 52);
+  test.equals(result[1].allocated, 27);
+  test.equals(result[2].allocated, 13);
+  test.equals(result[3].allocated, 9);
+  test.equals(result[4].allocated, 9);
+  test.equals(result[5].allocated, 8);
+  test.equals(result[6].allocated, 2);
+  test.equals(result[7].allocated, 0);
+  test.equals(result[8].allocated, 0);
+  test.equals(result[9].allocated, 0);
+  test.equals(result[10].allocated, 0);
+  test.equals(result[11].allocated, 0);
+  test.equals(result[12].allocated, 0);
+  test.equals(result[13].allocated, 0);
+
+  test.done();
+};
+
+module.exports['1999 NZ election'] = function(test) {
+  var parties,
+    result;
+
+  parties = [
+    { votes: 800199, electorates: 41 },
+    { votes: 629932, electorates: 22 },
+    { votes: 159859, electorates: 1 },
+    { votes: 145493, electorates: 0 },
+    { votes: 106560, electorates: 1 },
+    { votes: 87926, electorates: 1 },
+    { votes: 49154, electorates: 0 },
+    { votes: 23033, electorates: 0 },
+    { votes: 22687, electorates: 0 },
+    { votes: 11065, electorates: 1 },
+    { votes: 5949, electorates: 0 },
+    { votes: 5190, electorates: 0 },
+    { votes: 4008, electorates: 0 },
+    { votes: 3244, electorates: 0 },
+    { votes: 3191, electorates: 0 },
+    { votes: 2912, electorates: 0 },
+    { votes: 1712, electorates: 0 },
+    { votes: 1311, electorates: 0 },
+    { votes: 936, electorates: 0 },
+    { votes: 454, electorates: 0 },
+    { votes: 387, electorates: 0 },
+    { votes: 292, electorates: 0 }
+  ];
+
+  result = lague(parties, { seats: 120, threshold: 0.05 });
+
+  // allocated
+  test.equals(result[0].allocated, 49);
+  test.equals(result[1].allocated, 39);
+  test.equals(result[2].allocated, 10);
+  test.equals(result[3].allocated, 9);
+  test.equals(result[4].allocated, 7);
+  test.equals(result[5].allocated, 5);
+  test.equals(result[6].allocated, 0);
+  test.equals(result[7].allocated, 0);
+  test.equals(result[8].allocated, 0);
+  test.equals(result[9].allocated, 1);
+  test.equals(result[10].allocated, 0);
+  test.equals(result[11].allocated, 0);
+  test.equals(result[12].allocated, 0);
+  test.equals(result[13].allocated, 0);
+  test.equals(result[14].allocated, 0);
+  test.equals(result[15].allocated, 0);
+  test.equals(result[16].allocated, 0);
+  test.equals(result[17].allocated, 0);
+  test.equals(result[18].allocated, 0);
+  test.equals(result[19].allocated, 0);
+  test.equals(result[20].allocated, 0);
+  test.equals(result[21].allocated, 0);
+
+  test.done();
+};
+
+module.exports['1996 NZ election'] = function(test) {
+  var parties,
+    result;
+
+  parties = [
+    { votes: 701315, electorates: 30 },
+    { votes: 584159, electorates: 26 },
+    { votes: 276603, electorates: 6 },
+    { votes: 209347, electorates: 1 },
+    { votes: 126442, electorates: 1 },
+    { votes: 89716, electorates: 0 },
+    { votes: 34398, electorates: 0 },
+    { votes: 18245, electorates: 1 },
+    { votes: 5990, electorates: 0 },
+    { votes: 5288, electorates: 0 },
+    { votes: 4070, electorates: 0 },
+    { votes: 3543, electorates: 0 },
+    { votes: 3189, electorates: 0 },
+    { votes: 2514, electorates: 0 },
+    { votes: 2363, electorates: 0 },
+    { votes: 1431, electorates: 0 },
+    { votes: 1244, electorates: 0 },
+    { votes: 949, electorates: 0 },
+    { votes: 671, electorates: 0 },
+    { votes: 478, electorates: 0 },
+    { votes: 404, electorates: 0 }
+  ];
+
+  result = lague(parties, { seats: 120, threshold: 0.05 });
+
+  // allocated
+  test.equals(result[0].allocated, 44);
+  test.equals(result[1].allocated, 37);
+  test.equals(result[2].allocated, 17);
+  test.equals(result[3].allocated, 13);
+  test.equals(result[4].allocated, 8);
+  test.equals(result[5].allocated, 0);
+  test.equals(result[6].allocated, 0);
+  test.equals(result[7].allocated, 1);
+  test.equals(result[8].allocated, 0);
+  test.equals(result[9].allocated, 0);
+  test.equals(result[10].allocated, 0);
+  test.equals(result[11].allocated, 0);
+  test.equals(result[12].allocated, 0);
+  test.equals(result[13].allocated, 0);
+  test.equals(result[14].allocated, 0);
+  test.equals(result[15].allocated, 0);
+  test.equals(result[16].allocated, 0);
+  test.equals(result[17].allocated, 0);
+  test.equals(result[18].allocated, 0);
+  test.equals(result[19].allocated, 0);
+  test.equals(result[20].allocated, 0);
 
   test.done();
 };


### PR DESCRIPTION
Support for options:
- Threshold
- Overhang 
- Tag Along (with variable seats)

Added tests:
- 7 complete election datasets
- 3 variations of 6 election datasets as per the [2012 NZ MMP Review](http://www.elections.org.nz/sites/default/files/bulk-upload/documents/Final_Report_2012_Review_of_MMP.pdf)
